### PR TITLE
Changed babel-eslint to @babel/eslint-parser package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     extends: "standard",
-    parser: "babel-eslint",
+    parser: "@babel/eslint-parser",
     plugins: ["mocha"],
     rules: {
         indent: [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "upgrade": "npx sort-package-json && ncu -u"
     },
     "dependencies": {
-        "babel-eslint": "^10.1.0",
+        "@babel/eslint-parser": "^7.12.1",
         "eslint-config-standard": "^14.1.1",
         "eslint-plugin-import": "^2.20.2",
         "eslint-plugin-mocha": "^7.0.1",
@@ -43,7 +43,7 @@
         "sort-package-json": "^1.44.0"
     },
     "peerDependencies": {
-        "babel-eslint": "^10.1.0",
+        "@babel/eslint-parser": "^7.12.1",
         "eslint": "^7.1.0",
         "eslint-config-standard": "^14.1.1",
         "eslint-plugin-import": "^2.20.2",

--- a/vue.js
+++ b/vue.js
@@ -4,7 +4,7 @@ module.exports = {
     extends: ["hive", "plugin:vue/essential", "plugin:vue/recommended"],
     plugins: ["vue"],
     parserOptions: {
-        parser: "babel-eslint"
+        parser: "@babel/eslint-parser"
     },
     rules: {
         "vue/html-indent": ["error", 4],


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | A problem was found in a specific line of code such as the one below, which causes the error in the image.|
| Decisions | After investigating, the [`babel-eslint`](https://github.com/babel/babel-eslint) package is archived and the it is [advisable](https://github.com/eslint/eslint/issues/13750#issuecomment-707636108) to change to `@babel/eslint-parser`. |

```
const properties = this.stuff?.map(p => ({
      value: p.name,
      label: this.func(
         `properties.${p.type}.${p.name}`,
          this.func1(this.func2(p.name))
      ),
      type: p.type
}));
```
![image](https://user-images.githubusercontent.com/25725586/97976739-fe2aa280-1dc2-11eb-9fc1-e8dd91a54719.png)