### PR TITLE
Set babel configuration file requirement as false

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 module.exports = {
     extends: "standard",
     parser: "@babel/eslint-parser",
+    parserOptions: {
+        requireConfigFile: false
+    },
     plugins: ["mocha"],
     rules: {
         indent: [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "upgrade": "npx sort-package-json && ncu -u"
     },
     "dependencies": {
+        "@babel/core": "^7.12.3",
         "@babel/eslint-parser": "^7.12.1",
         "eslint-config-standard": "^14.1.1",
         "eslint-plugin-import": "^2.20.2",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | My mistake, errors appear in some repositories: <br> ![image](https://user-images.githubusercontent.com/25725586/98004778-3b555b80-1de8-11eb-9642-0392eaea1b91.png) <br> |
| Decisions | Set `requireConfigFile` as false, meaning that no .babelrc file will be provided. Also import @babel/core, see https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint. |