### PR TITLE
feat: moved dependencies to peerDependencies, new rule and bump packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [10, 11, 12, 13, 14]
+        node-version: [10, 11, 12, 13, 14, 16]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support for node 16
+* Turn off rule `vue/multi-word-component-names`
 
 ### Changed
 
 * Bumped some of the packages
+* Moved dependencies to peerDependencies
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -26,20 +26,20 @@
         "prettier": "prettier \"./**/*.{js,json}\" --write",
         "upgrade": "npx sort-package-json && ncu -u"
     },
-    "dependencies": {
-        "@babel/core": "^7.17.2",
+    "peerDependencies": {
+        "@babel/core": "^7.18.0",
         "@babel/eslint-parser": "^7.17.0",
-        "eslint-config-standard": "^16.0.3",
-        "eslint-plugin-import": "^2.25.4",
-        "eslint-plugin-mocha": "^10.0.3",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-mocha": "^10.0.4",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.0.0",
-        "eslint-plugin-vue": "^8.4.1"
+        "eslint-plugin-vue": "^9.0.1"
     },
     "devDependencies": {
-        "npm-check-updates": "^12.3.0",
-        "prettier": "^2.5.1",
+        "npm-check-updates": "^13.0.3",
+        "prettier": "^2.6.2",
         "prettier-config-hive": "^0.1.7",
-        "sort-package-json": "^1.54.0"
+        "sort-package-json": "^1.57.0"
     }
 }

--- a/vue.js
+++ b/vue.js
@@ -9,15 +9,19 @@ module.exports = {
     rules: {
         "vue/component-tags-order": "off",
         "vue/one-component-per-file": "off",
+        "vue/multi-word-component-names": "off",
         "vue/html-indent": ["error", 4],
         "vue/component-definition-name-casing": ["error", "kebab-case"],
         "vue/v-on-style": ["error", "longform"],
         "vue/v-bind-style": ["error", "longform"],
-        "vue/v-slot-style": ["error", {
-            "atComponent": "v-slot",
-            "default": "v-slot",
-            "named": "longform",
-        }],
+        "vue/v-slot-style": [
+            "error",
+            {
+                atComponent: "v-slot",
+                default: "v-slot",
+                named: "longform"
+            }
+        ],
         "vue/max-attributes-per-line": [
             "error",
             {
@@ -54,43 +58,46 @@ module.exports = {
                 ]
             }
         ],
-        "vue/order-in-components": ["error", {
-            "order": [
-                "el",
-                "name",
-                "key",
-                "parent",
-                "functional",
-                ["delimiters", "comments"],
-                ["components", "directives", "filters"],
-                "extends",
-                "mixins",
-                ["provide", "inject"],
-                "layout",
-                "middleware",
-                "validate",
-                "scrollToTop",
-                "transition",
-                "loading",
-                "inheritAttrs",
-                "model",
-                ["props", "propsData"],
-                "emits",
-                "setup",
-                "asyncData",
-                "data",
-                "fetch",
-                "head",
-                "computed",
-                "watch",
-                "watchQuery",
-                "LIFECYCLE_HOOKS",
-                "ROUTER_GUARDS",
-                "methods",
-                ["template", "render"],
-                "renderError"
-            ]
-        }],
+        "vue/order-in-components": [
+            "error",
+            {
+                order: [
+                    "el",
+                    "name",
+                    "key",
+                    "parent",
+                    "functional",
+                    ["delimiters", "comments"],
+                    ["components", "directives", "filters"],
+                    "extends",
+                    "mixins",
+                    ["provide", "inject"],
+                    "layout",
+                    "middleware",
+                    "validate",
+                    "scrollToTop",
+                    "transition",
+                    "loading",
+                    "inheritAttrs",
+                    "model",
+                    ["props", "propsData"],
+                    "emits",
+                    "setup",
+                    "asyncData",
+                    "data",
+                    "fetch",
+                    "head",
+                    "computed",
+                    "watch",
+                    "watchQuery",
+                    "LIFECYCLE_HOOKS",
+                    "ROUTER_GUARDS",
+                    "methods",
+                    ["template", "render"],
+                    "renderError"
+                ]
+            }
+        ],
         "vue/singleline-html-element-content-newline": [
             "error",
             {


### PR DESCRIPTION
Using node@16, there is problems installing the dependencies in this package, as well as using this package as a dependency.
As it can be seen in https://github.com/ripe-tech/ripe-id-api-js/pull/15#pullrequestreview-982004028, the dependencies of this package are not found by it.
This happens because the dependencies are installed in the root of the node modules instead of the node modules of the dependency.

![image](https://user-images.githubusercontent.com/25725586/169982296-59e43c91-fd25-4168-88ee-0fe4fc6db29f.png)

This is similar to what happened with `stylelint_config_hive`, so this PR does 3 things:

* Moved all dependencies to `peerDependencies`, like we have in `stylelint_config_hive`
* Turned of rule [`vue/multi-word-component-names`](https://eslint.vuejs.org/rules/multi-word-component-names.html), which forces component to have more than one name - `Home` :x: `TodoItem` :heavy_check_mark: - this is not a standard we usually follow
* Bumped packages
* Added node 16 to the CI
